### PR TITLE
リンクの中身をタップできなくする

### DIFF
--- a/lib/src/mfm_inline_span.dart
+++ b/lib/src/mfm_inline_span.dart
@@ -225,13 +225,15 @@ class MfmInlineSpan extends TextSpan {
             baseline: TextBaseline.alphabetic,
             child: GestureDetector(
               onTap: () => Mfm.of(context).linkTap?.call(node.url),
-              child: MfmElementWidget(
-                style: style?.merge(
-                  Mfm.of(context).linkStyle ??
-                      TextStyle(color: Theme.of(context).primaryColor),
+              child: AbsorbPointer(
+                child: MfmElementWidget(
+                  style: style?.merge(
+                    Mfm.of(context).linkStyle ??
+                        TextStyle(color: Theme.of(context).primaryColor),
+                  ),
+                  nodes: node.children,
+                  depth: depth + 1,
                 ),
-                nodes: node.children,
-                depth: depth + 1,
               ),
             ),
           )


### PR DESCRIPTION
Fix shiosyakeyakini-info/miria#425

リンクのラベルのノードをAbsorbPointerで囲むことで、GestureDetectorが付いた絵文字などがラベルに使われているときにジェスチャーが奪われないようにしました