### PR TITLE
`mfm_renderer`を`mfm`に置き換える

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This package supports these MFM syntaxes.
 ## Getting started
 
 ```
-flutter pub add mfm_renderer
+flutter pub add mfm
 ```
 
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_highlighting/flutter_highlighting.dart';
 import 'package:flutter_highlighting/themes/github-dark.dart';
 import 'package:highlighting/languages/all.dart';
-import 'package:mfm_renderer/mfm_renderer.dart';
+import 'package:mfm/mfm.dart';
 import 'package:http/http.dart' as http;
 
 void main() {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -163,6 +163,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.0"
+  mfm:
+    dependency: "direct main"
+    description:
+      path: ".."
+      relative: true
+    source: path
+    version: "1.0.2"
   mfm_parser:
     dependency: transitive
     description:
@@ -171,13 +178,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
-  mfm_renderer:
-    dependency: "direct main"
-    description:
-      path: ".."
-      relative: true
-    source: path
-    version: "0.0.1"
   path:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   cupertino_icons: ^1.0.2
-  mfm_renderer:
+  mfm:
     path: ../
   http: ^1.1.0
   flutter_highlighting: ^0.9.0+11.8.0


### PR DESCRIPTION
exampleコードの一部が`mfm_renderer`のままで、そのままではビルドできないため`mfm`に修正しました。
また、README.mdのGetting startedも同様に修正しました。