### PR TITLE
fgとbgで色が不正なとき赤を使う

### DIFF
--- a/lib/src/mfm_fn_span.dart
+++ b/lib/src/mfm_fn_span.dart
@@ -112,7 +112,7 @@ class MfmFnSpan extends TextSpan {
           child: MfmElementWidget(
             nodes: function.children,
             style: style?.merge(TextStyle(
-                color: (function.args["color"] as String?)?.color,
+                color: (function.args["color"] as String?)?.color ?? Colors.red,
                 height: Mfm.of(context).lineHeight)),
             depth: depth + 1,
           ),
@@ -127,8 +127,9 @@ class MfmFnSpan extends TextSpan {
           alignment: resolveAlignment(function.children ?? []),
           baseline: TextBaseline.alphabetic,
           child: Container(
-            decoration:
-                BoxDecoration(color: (function.args["color"] as String?).color),
+            decoration: BoxDecoration(
+              color: (function.args["color"] as String?).color ?? Colors.red,
+            ),
             child: MfmElementWidget(
               nodes: function.children,
               style: style?.copyWith(height: Mfm.of(context).lineHeight),


### PR DESCRIPTION
Misskey Webでは `$[fg text]` のように色を指定しない場合や `$[bg.color=x text]` のように不正なカラーコードが与えられる場合、代わりに#f00を使っています

https://github.com/misskey-dev/misskey/blob/c1019a006bfa48ba7398daa02788c50be0bfb35a/packages/frontend/src/components/global/MkMisskeyFlavoredMarkdown.ts#L250

同様に表示するため、色が解釈されなかった場合に `Colors.red` を使うようにしました