### PR TITLE
リンクブロックにMouseRegionとTooltipを追加

### DIFF
--- a/lib/src/mfm_inline_span.dart
+++ b/lib/src/mfm_inline_span.dart
@@ -222,15 +222,21 @@ class MfmInlineSpan extends TextSpan {
           WidgetSpan(
             alignment: PlaceholderAlignment.baseline,
             baseline: TextBaseline.alphabetic,
-            child: GestureDetector(
-              onTap: () => Mfm.of(context).linkTap?.call(node.url),
-              child: MfmElementWidget(
-                style: style?.merge(
-                  Mfm.of(context).linkStyle ??
-                      TextStyle(color: Theme.of(context).primaryColor),
+            child: MouseRegion(
+              cursor: SystemMouseCursors.click,
+              child: Tooltip(
+                message: node.url,
+                child: GestureDetector(
+                  onTap: () => Mfm.of(context).linkTap?.call(node.url),
+                  child: MfmElementWidget(
+                    style: style?.merge(
+                      Mfm.of(context).linkStyle ??
+                          TextStyle(color: Theme.of(context).primaryColor),
+                    ),
+                    nodes: node.children,
+                    depth: depth + 1,
+                  ),
                 ),
-                nodes: node.children,
-                depth: depth + 1,
               ),
             ),
           )


### PR DESCRIPTION
リンクブロックにMouseRegionとTooltipを追加する提案です。

- MouseRegion: クリック可能なリンクであることをわかりやすくするため
- Tooltip: 下記のような偽装方法への耐性を*少しだけ*上げるため
![Screenshot from 2025-06-30 21-04-02](https://github.com/user-attachments/assets/bc7c6986-0b7e-40b6-9447-c586bf660a69)
